### PR TITLE
Add Lit component test coverage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+# Handles Shared Lit Components Docs
+
+This repository packages the shared Lit-based UI building blocks used across the Kora Labs and Handles frontend ecosystem. The library is small, but it sits on top of important product flows: connecting a Cardano wallet, choosing a handle, confirming user intent, and surfacing transient errors. These docs exist to make the package understandable without reverse-engineering Storybook stories or inspecting each component file by hand.
+
+## Product Docs
+
+- [Product Overview](./product/overview.md)
+- [Component Catalog](./product/component-catalog.md)
+
+## Spec Docs
+
+- [Architecture And Packaging](./spec/architecture.md)
+- [Component Contracts](./spec/component-contracts.md)
+- [Build, Storybook, And Release](./spec/build-release.md)
+
+## Scope
+
+The documentation set is intentionally split into product and spec layers:
+
+- `docs/product` explains why the package exists, which user journeys it supports, and how consuming apps are expected to use it.
+- `docs/spec` explains how the package is laid out, what each component exposes, how it is built and published, and where the current implementation has gaps or coupling that maintainers should understand before extending it.
+
+## Current Reality
+
+The repository had no `docs/product` or `docs/spec` content before this update. The package also has a minimal source export surface at the root, a Storybook setup driven by compiled output, and a deploy workflow that publishes on `master`. Those facts are documented explicitly in the linked spec pages so future changes can be made with the actual codebase constraints in mind.

--- a/docs/product/component-catalog.md
+++ b/docs/product/component-catalog.md
@@ -1,0 +1,428 @@
+# Component Catalog
+
+This catalog explains each shipped component family in product terms. The goal is not just to list tags and props, but to answer the more important question: when should a Handles product use each component, and what must the parent application still own?
+
+## Reading The Catalog
+
+Each entry focuses on:
+
+- the user problem the component solves
+- the expected host responsibilities
+- the notable interaction model
+- the most important caveats in the current implementation
+
+For low-level implementation details, see the spec pages. This catalog stays product-facing.
+
+## Shared Buttons
+
+### `shared-button-small`
+### `shared-button-medium`
+### `shared-button-large`
+
+These three custom elements provide the package’s simplest CTA primitive. They share one visual style and differ only in padding and font size.
+
+Use them when:
+
+- you want a pill-shaped button that already matches the Handles component styling
+- the component is being rendered inside another Lit component in this package or a sibling repo
+- your design needs size variants without introducing another button system
+
+What the parent provides:
+
+- button label content via the named slot `shared-button`
+- optional `buttonColor`
+- optional `textColor`
+
+Product notes:
+
+- The button family is appropriate for dialogs, confirmations, or contained actions.
+- It is not a fully featured button system. There are no variants for disabled, loading, destructive, or icon-leading states beyond what a consumer can style manually.
+- The styles are intentionally minimal and can function as a lightweight shared default rather than a complete design language.
+
+Current caveats:
+
+- The root package export does not expose the button classes directly through `src/index.ts`. Consumers usually rely on side-effect imports from the component path.
+- The slot-based label API is slightly more cumbersome than a plain `label` prop but works well inside other custom elements.
+
+## `select-wallet`
+
+`select-wallet` is the package’s wallet chooser shell. It renders a titled selection panel, a scrollable list of wallet options, and a bottom slot for action buttons.
+
+Use it when:
+
+- the user needs to choose one supported Cardano wallet extension before continuing
+- you want a consistent wallet picker across multiple Handles experiences
+- the app already knows which wallets are installed or supported
+
+What the parent provides:
+
+- a `wallets` array of wallet objects with `key`, `name`, and `icon`
+- an `onSelectWallet` function for click handling
+- optionally `onScroll` and `onFirstUpdated`
+- optional slotted footer buttons via `slottedButtons`
+
+What the user sees:
+
+- a “Choose your wallet” header
+- one row per wallet
+- an empty state when no wallets are present
+- a visual radio-style indicator intended to show which wallet is selected
+
+Product integration guidance:
+
+- This component is best paired with app logic that discovers wallets through `window.cardano`, normalizes them into the expected shape, and decides what to do after selection.
+- If your flow needs an immediate one-click connect behavior, the `onSelectWallet` callback can do that. If your flow needs a second confirm step, add buttons in the footer slot.
+
+Current caveats:
+
+- The component tracks an internal `selectedWallet` state but does not update that state when a wallet is clicked. The click handler calls `onSelectWallet(wallet)` only. That means the host app should not assume the built-in selected styling is currently authoritative.
+- The component uses callback properties rather than custom DOM events, so the parent must pass functions instead of listening for emitted events.
+
+## `select-handle`
+
+`select-handle` is the compact list-oriented handle chooser. It is meant for flows where users need to pick one handle from a set and where text scanning matters more than a gallery presentation.
+
+Use it when:
+
+- the app has already loaded a list of wallet-owned handles
+- the user needs to switch or confirm an active handle
+- you want a vertical list with a current-selection summary near the top
+- the surrounding flow needs custom search, footer buttons, or loading content
+
+What the parent provides:
+
+- `handleData`, an array of handle-like objects
+- `activeHandle`, the currently active item
+- `imageUrl`, the image URL shown for the active item and selected list row
+- `loadingImg`, to control when the loader slot replaces the image
+- `onSelectHandle`, `onScroll`, and optionally `onFirstUpdated`
+- slotted content for `slottedSearch`, `slottedButtons`, and `slottedLoader`
+- optional inline style strings for the search and button wrapper regions
+
+What the user sees:
+
+- a search area at the top
+- an optional current-handle card when `activeHandle.name` exists
+- a scrollable list of handle names, each prefixed with `$`
+- optional loader content when selection or list loading is in progress
+- a footer action area
+
+Product integration guidance:
+
+- This component works best when paired with `handle-small-search`, although it can accept any search UI through the slot.
+- The parent app should treat the component as a controlled renderer. It should update `activeHandle`, `imageUrl`, and `loadingImg` in response to user selection and data fetching.
+- If the list is paginated or lazily loaded, the `onScroll` callback can be used to trigger loading near the bottom of the scroll container.
+
+Current caveats:
+
+- The component assumes the consumer has already resolved a displayable image URL for the active handle.
+- The list items render only the handle name, not per-item thumbnails, unless the item is the active handle.
+- The component uses function properties rather than emitting semantic custom events.
+
+## `large-handle-selector`
+
+`large-handle-selector` is the image-first alternative to `select-handle`. It renders a gallery of handle images and automatically adjusts image sizing based on the number of items.
+
+Use it when:
+
+- visual identity matters and the handle art should be front-and-center
+- the number of handles is small enough to browse as a grid or gallery
+- the UI benefits from a more premium or collectible presentation than a compact list
+
+What the parent provides:
+
+- `handleData`, typically in the shared `WalletHandle` shape or a compatible subset
+- `onSelectHandle`, `onScroll`, and optionally `onFirstUpdated`
+- a `slottedSearch` region if filtering is needed
+- a `slottedLoader` for items missing an image
+- any handle-level active flag that should influence the selected styling
+
+What the user sees:
+
+- a “Choose your handle” title
+- a search region at the top
+- a scrollable area with gradient overlays
+- one clickable card per handle image
+
+Product integration guidance:
+
+- This component fits flows where the visual rendering of a handle helps the user identify the correct asset.
+- The parent app should ensure images are pre-resolved and safe to display at the expected size.
+- The built-in dynamic sizing is useful for broad cases, but if a product needs exact layout control it may need a dedicated component rather than extending this one.
+
+Current caveats:
+
+- Image dimensions are inferred from list length with only three tiers: one item, two to ten items, or more than ten items.
+- The component shows loader slot content per item when the item lacks an image, but loading semantics remain consumer-defined.
+- The component exposes several properties such as `handleDataArray`, `dropdownOpen`, and `isLoading` that are not central to the current rendered output.
+
+## `dropdown-button`
+
+`dropdown-button` is a branded trigger wrapper for slotted dropdown content. It shows a Handles logo mark, the active handle label or a fallback prompt, and an arrow that reflects open state.
+
+Use it when:
+
+- you need a compact “active handle” control in a header or account widget
+- dropdown content is app-specific, but the trigger should look shared
+- you want to embed custom menu content through a slot rather than use a fixed menu implementation
+
+What the parent provides:
+
+- `dropdownHandle`, a display string for the current handle
+- `dropdownPositioning`, a style string used when the dropdown is open
+- slotted menu content in `slottedDropdown`
+
+What the user sees:
+
+- the Handles logo
+- either the current handle text or “Choose Handle”
+- an arrow that rotates when the dropdown is open
+- any slotted dropdown content when opened
+
+Product integration guidance:
+
+- This is a good fit when the parent app already knows what actions belong in the dropdown, such as switching handles, opening account settings, or connecting/disconnecting flows.
+- Because the component exposes the dropdown content through a slot, each consuming product can decide whether the content is a menu, a list, or a richer panel.
+
+Current caveats:
+
+- The component internally controls open/closed state and does not emit a toggle event.
+- It imports `LitElement` from `lit-element` rather than `lit`, unlike most of the package.
+- The styling of the open content is delegated to a raw inline style string, so positioning is flexible but not strongly typed.
+
+## `handle-small-search`
+
+`handle-small-search` is the package’s reusable text search field for handle filtering.
+
+Use it when:
+
+- a Handle-focused list or selector needs a compact, recognizable search bar
+- you want a built-in clear button and Handle-specific placeholder behavior
+- the parent app is prepared to receive and act on input changes
+
+What the parent provides:
+
+- optionally `inputValue`
+- optionally `searching`
+- an event listener for the emitted `input-change` event
+
+What the user sees:
+
+- a search icon
+- placeholder text tuned to Handle search
+- a clear icon that appears when there is content
+- placeholder copy that changes on focus to hint at exact-match search with `$`
+
+Product integration guidance:
+
+- This is the natural search companion for `select-handle` and `large-handle-selector`.
+- The parent app should debounce or filter as needed; the component emits on every input change and does not perform its own querying.
+
+Current caveats:
+
+- The component trims the input value before dispatching it, which may be desirable for search but should be known by consumers.
+- The `clearSearch` method resets local state but does not dispatch another `input-change` event when clearing. If the parent needs a clearing event, it must wire that behavior separately or extend the component.
+
+## `disconnect-wallet-button`
+
+`disconnect-wallet-button` is a small affordance for leaving a connected wallet session. It swaps between the connected wallet icon and a disconnect icon on hover.
+
+Use it when:
+
+- the app already has a connected wallet session
+- you need a compact disconnect control rather than a full text button
+- the UI should reinforce the currently connected wallet visually
+
+What the parent provides:
+
+- optionally `walletIconUrl`
+- optionally `onClick`
+
+What the user sees:
+
+- the current wallet icon if present, otherwise a generic wallet icon
+- a hover swap to a disconnect glyph
+- a tooltip reading “Disconnect Wallet”
+
+Product integration guidance:
+
+- This is best used in account headers, wallet chips, or active-session controls where space is limited.
+- The host should own the actual disconnect logic, such as clearing session state and prompting the user if the action has broader consequences.
+
+Current caveats:
+
+- The component is intentionally narrow and does not ask for confirmation.
+- It relies on hover to reveal intent, so touch-first contexts may need supplemental labeling or surrounding UX cues.
+
+## `confirm-popup`
+
+`confirm-popup` is a modal-style confirmation dialog with two button actions.
+
+Use it when:
+
+- the user must explicitly confirm or cancel an action
+- the app needs a quick shared dialog rather than a custom modal system for one-off confirmations
+- the copy is short enough to fit the component’s fixed structure
+
+What the parent provides:
+
+- `open`
+- `message`
+- `secondMessage`
+- `confirmButtonLabel`
+- `cancelButtonLabel`
+- `onConfirm`
+- `onCancel`
+
+What the user sees:
+
+- two lines of confirmation text
+- a cancel button
+- a confirm button
+
+Product integration guidance:
+
+- This component is suitable for destructive or irreversible actions that do not need complex form content.
+- Because the component closes itself after either action, the parent should ensure the external `open` state remains consistent if it treats the component as controlled.
+
+Current caveats:
+
+- The component closes itself by mutating its own `open` property after firing callbacks.
+- Button labels are required for a complete UX; there are no internal defaults.
+- Rich content beyond two text lines is not currently supported.
+
+## `error-popup`
+
+`error-popup` is a dismissible transient error dialog with an auto-closing countdown and a progress bar.
+
+Use it when:
+
+- the app needs to surface a non-persistent error that should disappear automatically
+- the user benefits from seeing a title and message without needing to acknowledge a full-screen modal
+- the parent wants a shared Handles-styled error treatment
+
+What the parent provides:
+
+- `open`
+- `messageTitle`
+- `message`
+- optionally `countdown`
+- optionally slotted custom content in `customError`
+
+What the user sees:
+
+- an alert icon
+- title and message text
+- a close button
+- a bottom progress indicator that shrinks over time
+
+Product integration guidance:
+
+- This works well for operational errors that should be noticed but not block the user indefinitely.
+- The hover-to-pause behavior is useful when the user needs extra time to read the message.
+
+Current caveats:
+
+- The component dispatches `error-popup-closed` on `window`, not from the component instance. Consumers need to know that integration detail.
+- The `countdown` property exists, but the component also resets its internal state from a fixed `maxCountdown` of five seconds.
+- The component clears its timer when closing, but it is still best to mount and unmount it predictably from the parent app.
+
+## `custom-toggle`
+
+`custom-toggle` is a visual toggle pill with normal and small sizes.
+
+Use it when:
+
+- you need a branded on/off indicator
+- the parent app already owns the true boolean state
+- the interaction is simple enough that a presentational toggle is sufficient
+
+What the parent provides:
+
+- `isActive`
+- optionally `smallToggle`
+- click handling at the host level if the toggle should change state
+
+Current caveats:
+
+- The component does not toggle itself. It simply renders based on the provided property.
+- The current story manually mutates the property from a click handler, which accurately reflects the intended host-controlled pattern.
+
+## `custom-checkbox`
+
+`custom-checkbox` is the checkbox counterpart to `custom-toggle`: a branded visual shell for checked, unchecked, small, and disabled states.
+
+Use it when:
+
+- you need a Handles-style checkbox indicator
+- parent code already knows the state and handles any click or form integration
+
+What the parent provides:
+
+- `checked`
+- `smallCheckbox`
+- `disabled`
+
+Current caveats:
+
+- The component is presentational only. It does not integrate with forms or emit its own change event.
+- Accessibility and keyboard semantics must be handled by the host if the component is used as part of an interactive control.
+
+## `radio-button`
+
+`radio-button` is a minimal selected/unselected indicator with a compact mode.
+
+Use it when:
+
+- a parent component needs a consistent Handles-style radio visual
+- selection state is owned elsewhere and only the display is shared
+
+What the parent provides:
+
+- `isSelected`
+- `isSmall`
+
+Current caveats:
+
+- This is purely visual and does not represent a full accessible radio input on its own.
+
+## `custom-loader`
+
+`custom-loader` renders a dual-ring branded spinner using inline SVG and CSS animations.
+
+Use it when:
+
+- a Handle flow needs a compact, brand-aligned loading affordance
+- the parent app wants to place loader content into a slot such as `slottedLoader`
+
+Current caveats:
+
+- It is a function that returns a Lit template, not a registered custom element.
+- Consumers generally embed it in a host render tree rather than use a tag such as `<custom-loader>`.
+
+## `state-example`
+
+`state-example` is not a production product primitive. It is a simple demo component that shows reactive state and slot rendering.
+
+Use it when:
+
+- demonstrating Lit behavior locally
+- confirming the package build and Storybook loop still work
+
+Current caveats:
+
+- The text content is clearly example-oriented rather than user-facing product copy.
+- It is one of only two exports exposed by the package root today, which reflects current packaging reality rather than product importance.
+
+## How To Choose Between Similar Components
+
+If you are deciding between components, use the following heuristics:
+
+- Choose `select-wallet` when the user is picking a wallet extension.
+- Choose `select-handle` when the user is choosing from a text list and may need footer buttons.
+- Choose `large-handle-selector` when the handle image should drive recognition.
+- Choose `dropdown-button` when the user already has an active handle context and needs a compact launcher for additional choices.
+- Choose `handle-small-search` when you want a shared search affordance instead of building one inline.
+- Choose `confirm-popup` or `error-popup` when the app needs shared dialog treatments rather than custom message overlays.
+
+The spec docs describe how each component is wired, but from a product point of view the important distinction is this: most components in this package render a familiar shell around data and behaviors that still belong to the host application.

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -1,0 +1,235 @@
+# Product Overview
+
+## Purpose
+
+`@koralabs/handles-shared-lit-components` is the shared presentational component package for the Handles ecosystem’s Lit-based interfaces. It provides reusable UI primitives for the flows that show up repeatedly across the product suite:
+
+- wallet discovery and selection
+- handle selection from a wallet-owned list
+- dropdown presentation of the active handle
+- inline search for handle filtering
+- confirmation and error dialogs
+- small visual controls such as toggles, checkboxes, radio indicators, and buttons
+
+The package exists to keep these flows visually consistent between applications and to avoid duplicating the same markup, CSS, and interaction wiring in multiple sibling repos. It is not a product by itself. It is a supporting UI layer used by product surfaces such as minting, marketplace, account, and other Handle-enabled web experiences.
+
+## Product Role In The Ecosystem
+
+Within the Kora Labs ecosystem, this repo fills the space between low-level design tokens and full application features.
+
+- It is more specific than a general-purpose design system because many components are explicitly about wallet and handle workflows.
+- It is less opinionated than a finished application because it does not fetch data, maintain application state across screens, or decide business rules.
+- It is designed to be embedded into parent experiences that already know how to talk to Cardano wallets, resolve handle assets, and orchestrate user flows.
+
+In practice, that means the package is responsible for rendering polished interaction shells, while the parent app remains responsible for supplying data, choosing when components are shown, and reacting to user input.
+
+## Target Users
+
+There are two user groups to keep in mind:
+
+### 1. End Users Of Handles Products
+
+These users never install this package directly, but they experience it whenever a Handles product asks them to:
+
+- pick a wallet extension
+- choose one handle from a wallet with many handles
+- confirm a destructive or irreversible action
+- notice an error that should auto-dismiss unless they hover
+- search a long list of handles
+
+For this audience, the value proposition is consistency. A user who has already selected a wallet in one Handles flow should recognize the same selection, error, and confirmation patterns elsewhere.
+
+### 2. Internal Product Engineers
+
+These users import or side-effect-load the components into sibling repos. They care about:
+
+- stable custom element tags
+- predictable properties and callbacks
+- minimal styling surprises
+- a small dependency footprint
+- compatibility with existing Lit-based apps
+
+For this audience, the package reduces the cost of assembling Handle-aware flows and shortens the time required to ship UI that already matches the broader product family.
+
+## Problem Statement
+
+Without a shared package, every product team would have to rebuild the same core interaction surfaces:
+
+- a wallet picker with installed-wallet empty state
+- a list or grid selector for wallet-owned handles
+- a small search box with Handle-specific placeholder language
+- a dropdown button that can frame active handle choices
+- green/blue loading ornamentation consistent with the Handles brand
+- confirmation and error popups with the same button treatment
+
+That duplication would create several problems:
+
+- inconsistent markup and interaction details across products
+- repeated styling work whenever the brand evolves
+- higher risk of subtle UX regressions in wallet and handle flows
+- more difficult onboarding for new engineers who must learn multiple homegrown implementations
+
+This repository solves those problems by centralizing the repeated UI shells and by providing one package that sibling applications can reuse.
+
+## What The Package Is Responsible For
+
+The package is responsible for the following product concerns:
+
+- rendering the visual frame of selection dialogs, popups, and controls
+- exposing slots where parent applications can insert search bars, buttons, and loaders
+- rendering lists of wallets or handles using consumer-supplied data
+- exposing callbacks or browser events when the user interacts with a component
+- carrying forward the Handles visual language, especially the green and blue accent palette used in loaders and selected states
+
+Several components also encode product-specific copy that a general-purpose UI toolkit would not know about, such as:
+
+- “Choose your wallet”
+- “Choose your handle”
+- “No supported wallet extensions found.”
+- search placeholders centered on handles
+- handle display conventions that prefix the name with `$`
+
+That copy makes the package more useful out of the box for Handle flows, but it also means the package is tightly coupled to the Handles product domain.
+
+## What The Package Is Not Responsible For
+
+The package should not be treated as the owner of business logic. In the current implementation it does not:
+
+- discover wallets from `window.cardano`
+- fetch wallet-owned handles
+- resolve IPFS URIs into gateway URLs
+- decide which handle is active
+- store state outside the component instance
+- manage routing or modal lifecycle for the parent application
+- enforce permissions or validation rules
+- translate strings for multiple locales
+
+Instead, consumers are expected to provide data and behavior from the parent app. For example:
+
+- `select-wallet` expects a `wallets` array and an `onSelectWallet` callback.
+- `select-handle` expects `handleData`, `activeHandle`, `imageUrl`, `loadingImg`, and callback functions.
+- `large-handle-selector` expects a list of handle-like objects and a selection callback.
+- `handle-small-search` emits an `input-change` event, but the parent decides how to filter results.
+
+This separation is useful because wallet, chain, and data concerns vary between sibling products, but it also means integrators must understand that these components are mostly controlled or semi-controlled shells rather than autonomous feature modules.
+
+## Supported Product Journeys
+
+### Wallet Selection
+
+The package supports the first step of many Handle experiences: asking the user to choose a wallet extension. `select-wallet` renders the list, displays the wallet icon and name, and offers an empty state if no supported wallet extensions are detected. A parent application can add action buttons through a slot, making the component suitable for “Continue” and “Cancel” style flows.
+
+### Handle Selection In A Compact List
+
+`select-handle` exists for flows where the user must choose one wallet-owned handle from a vertical list. It supports:
+
+- a slotted search area
+- a current-handle summary row
+- a scrollable list for additional handles
+- an optional loader slot while the current item or list is being resolved
+- a slotted action area for confirm or navigation buttons
+
+This makes it appropriate for wallet login flows, active-handle switching, or account settings screens where a compact list is easier to scan than a large image gallery.
+
+### Handle Selection In A Large Visual Grid
+
+`large-handle-selector` supports a more visual selection flow by rendering handle images at different sizes based on how many items are present. That behavior suggests use in contexts where the artwork or rendered image matters, not just the handle name. The component still delegates search and loading to the consumer through slots and callback props, but it shifts the emphasis from text rows to image cards.
+
+### Active Handle Dropdown
+
+`dropdown-button` wraps a trigger and slotted dropdown content so parent applications can present handle-specific actions or options. The component’s copy defaults to “Choose Handle” when no active handle string is supplied. This makes it suitable for header widgets or compact account controls where the user needs a quick way to inspect or switch handle-related actions.
+
+### Search, Feedback, And Confirmation
+
+The package rounds out the core flows with supporting feedback controls:
+
+- `handle-small-search` for inline filtering
+- `confirm-popup` for user confirmation
+- `error-popup` for transient errors with a countdown indicator
+- `disconnect-wallet-button` for the wallet exit affordance
+- `custom-loader` for brand-aligned loading feedback
+
+These pieces are intentionally narrow. They are meant to be composed into a parent flow rather than treated as whole pages.
+
+## Design Principles
+
+The implementation suggests several de facto product principles.
+
+### Domain Specific Over Generic
+
+This is not a neutral component set. Names, copy, examples, and visual treatment all assume the Handles domain. That is a feature, not an accident. The goal is to optimize for the actual product family rather than maximize reuse outside it.
+
+### Parent-Controlled Data
+
+Components render what they are given. The parent is expected to own:
+
+- data retrieval
+- selection state
+- loading semantics
+- cross-component coordination
+
+That keeps the components simple and reduces hidden coupling to application services.
+
+### Composable Surface Areas
+
+Slots are used where the same shell needs different child content across products. For example, `select-handle` does not force one search input or one button set. It provides named insertion points, letting each app reuse the same frame while composing in its own search, action, or loader elements.
+
+### Brand Consistency
+
+Several components use recurring design motifs:
+
+- green and blue brand accents
+- rounded containers and controls
+- capsule-style buttons
+- prominent selection borders
+- inline SVG icons instead of external icon libraries
+
+That consistency matters because wallet and handle flows often appear inside larger, more complex applications. Reusing these motifs helps those flows feel like one family even when the surrounding page differs.
+
+## Data Expectations
+
+The package relies on the parent app to normalize data into the shapes the components expect.
+
+### Wallet Data
+
+`select-wallet` expects wallet objects with at least:
+
+- `key`
+- `name`
+- `icon`
+
+The code examples and stories imply the icon can be a URL or a data URL. The disconnect button docs also note that wallet icons are expected to come from the `window.cardano` wallet interface.
+
+### Handle Data
+
+The repo defines a `WalletHandle` interface in `src/interfaces/index.ts`. The type includes:
+
+- asset identity fields such as `policyId` and `hex`
+- a `name`
+- an optional `image` or `imageUrl`
+- an `active` marker
+- a `default` marker
+- optional chain-adjacent data like `utxo`, `price`, and `validUntilDate`
+
+Not every component consumes every field, but the shared type shows the intended product direction: handle selection UI should work with assets that already carry enough metadata for display, active/default state, and possible downstream commerce or validity flows.
+
+## Operational Constraints For Consumers
+
+Consumers should treat this package as UI infrastructure with explicit responsibilities.
+
+- You must pass already-usable image URLs if you expect images to render. The components do not resolve IPFS or asset metadata on their own.
+- You must own loading state. Components can show a loader slot or switch appearance, but they do not fetch asynchronously by themselves.
+- You must handle selection side effects. Most components call a provided function or emit an event; they do not update broader application state.
+- You must decide modal lifecycle in the parent app. Some components mutate their own `open` state, but route, overlay, and screen-level behavior still belong to the consumer.
+- You should not assume every control is interactive by itself. Some are presentation-only indicators and need parent wiring to become part of a completed UX flow.
+
+## Success Criteria
+
+This package is successful when it helps sibling applications ship Handle-specific UI faster without creating a maintenance trap. In practical terms, that means:
+
+- engineers can discover the available components quickly
+- consumers know which props, slots, callbacks, and events they must supply
+- wallet and handle flows look and feel consistent across products
+- maintainers can extend the package without accidentally changing hidden assumptions
+
+The rest of the documentation set focuses on those operational details so the package can be reused confidently instead of treated like an opaque bundle of old Storybook examples.

--- a/docs/spec/architecture.md
+++ b/docs/spec/architecture.md
@@ -1,0 +1,292 @@
+# Architecture And Packaging
+
+## Repository Shape
+
+This repo is a TypeScript package built around Lit custom elements and a small number of template-returning helpers. The important top-level folders are:
+
+- `src/web-components`: primary Lit custom elements
+- `src/components`: template helpers, including a button template and a loader template
+- `src/stories`: Storybook stories used to demonstrate the components
+- `src/interfaces`: shared TypeScript interfaces for handle-shaped data
+- `lib`: compiled output produced by `tsc`
+- `.storybook`: local Storybook configuration
+- `.github/workflows`: publish automation
+
+There was no documentation tree before this update, which meant maintainers had to infer the package structure by scanning source files. This page documents the effective architecture as it exists now.
+
+## Runtime Model
+
+The package uses Lit and Lit decorators for nearly all component logic.
+
+- Most elements extend `LitElement` from `lit`.
+- Properties are declared with `@property`.
+- Internal reactive state uses `@state` where needed.
+- Named custom elements are registered with `@customElement(...)` in most files, except the shared button family, which uses explicit `customElements.define(...)`.
+- Styles usually live in colocated `styles.ts` modules and are assigned with `static styles = ...`.
+
+This architecture keeps each component self-contained:
+
+- markup lives in the component file
+- CSS lives beside the component
+- state and lifecycle methods stay local to the element
+
+The result is straightforward to consume from another Lit-based project because the main dependency is just Lit itself.
+
+## Source Families
+
+### `src/web-components`
+
+This folder contains the package’s primary reusable UI elements:
+
+- `Button`
+- `ConfirmPopup`
+- `CustomCheckBox`
+- `CustomToggle`
+- `DisconnectWalletButton`
+- `DropdownButton`
+- `ErrorPopup`
+- `LargeHandleSelector`
+- `RadioButton`
+- `SelectHandle`
+- `SelectWallet`
+- `SmallHandleSearch`
+- `StateExample`
+
+Most product value in the repository lives here.
+
+### `src/components`
+
+This folder currently holds two template helpers:
+
+- `Button`, a template function with React-flavored props naming but still implemented via Lit templates
+- `CustomLoader`, a branded SVG loader
+
+These helpers are not registered custom elements. They are render helpers that return `html` templates.
+
+### `src/stories`
+
+The Storybook stories demonstrate basic usage of each component. They are also a useful source of truth for intended props and example composition, especially in a repo with little existing documentation.
+
+Important limitation: stories are examples, not hard guarantees. Some stories reveal intent more clearly than the component contracts do, but a few include naming mismatches or assumptions that are not fully reflected in the runtime behavior.
+
+### `src/interfaces`
+
+`src/interfaces/index.ts` defines the `WalletHandle` interface and its supporting asset shapes. This is the closest thing the package has to a shared domain contract.
+
+The type suggests that Handle UI in this repo is expected to work with asset-like objects carrying:
+
+- chain identity fields
+- a human-readable name
+- optional image data
+- flags such as `active` and `default`
+- optional pricing or validity metadata
+
+Even when an individual component uses only a small subset of that shape, the interface documents the intended domain model for Handle-bearing assets.
+
+## Export Surface
+
+The root `src/index.ts` currently exports only:
+
+- `StateExample`
+- `CustomLoader`
+
+That is a critical architectural fact. Many other components are available in source and compile into `lib`, but they are not re-exported from the package root.
+
+Implications:
+
+- Consumers may rely on direct path imports or side-effect imports instead of clean package-level named exports.
+- The public API is narrower than the repository contents might suggest.
+- Any future effort to make this a cleaner consumable package should start by intentionally defining the export surface rather than assuming all components are already part of it.
+
+This repo therefore behaves more like a bundle of importable modules than a fully curated package API.
+
+## Component Communication Patterns
+
+The components use three main integration patterns.
+
+### 1. Callback Properties
+
+Several components accept function-valued properties such as:
+
+- `onSelectWallet`
+- `onSelectHandle`
+- `onScroll`
+- `onFirstUpdated`
+- `onConfirm`
+- `onCancel`
+
+This is the dominant interaction model for higher-level selectors and dialogs. The parent application passes functions, and the component invokes them directly.
+
+Advantages:
+
+- simple to wire in Lit templates
+- no extra event object parsing
+- easy to keep logic in the parent component
+
+Tradeoffs:
+
+- less idiomatic for generic Web Component consumers than custom events
+- harder to inspect with browser tooling than DOM events
+- introduces a tighter coupling between the consumer and the component’s expected property shape
+
+### 2. Custom DOM Events
+
+Only a small portion of the package emits semantic events:
+
+- `handle-small-search` emits `input-change` with `detail: { inputValue }`
+- `error-popup` dispatches `error-popup-closed`, but it does so on `window`, not as a bubbled event from the element
+
+This mixed model is important to understand. Consumers cannot assume a consistent event-driven contract across the package.
+
+### 3. Named Slots
+
+Slots are used for composition where a shell needs consumer-provided children:
+
+- `select-wallet`: `slottedButtons`
+- `select-handle`: `slottedSearch`, `slottedButtons`, `slottedLoader`
+- `large-handle-selector`: `slottedSearch`, `slottedLoader`
+- `dropdown-button`: `slottedDropdown`
+- `error-popup`: `customError`
+- button family: `shared-button`
+
+Slots make the higher-level selectors more reusable across sibling products because the frame is standardized without freezing every piece of child content.
+
+## Styling Model
+
+The styling strategy is pragmatic and local:
+
+- most components use static CSS from a colocated `styles.ts`
+- some components inline styles directly in the render output
+- several container layout adjustments are passed in as raw style strings through properties like `slottedButtonsStyling`, `slottedSearchStyling`, or `dropdownPositioning`
+
+This gives consumers flexibility, but it has architectural consequences:
+
+- there is no strong type safety around inline style strings
+- styling contracts live partly in code and partly in informal usage expectations
+- host apps can influence layout without piercing shadow DOM CSS, but the mechanism is not as structured as CSS custom properties or named parts
+
+The only explicit CSS custom property usage in the repo today appears in `state-example`, which uses `--my-counter-text-color`.
+
+## Lifecycle Usage
+
+Most components keep lifecycle logic minimal.
+
+- `firstUpdated()` is used in `select-wallet`, `select-handle`, and `large-handle-selector` to invoke a supplied callback.
+- `error-popup` uses `connectedCallback`, `disconnectedCallback`, and `firstUpdated` for countdown management and hover pause behavior.
+
+This makes the components easy to follow, but it also means most lifecycle coordination is intentionally pushed outward to the consuming app.
+
+## Data Contracts
+
+### Wallet Objects
+
+The package does not define a first-class wallet TypeScript interface, but the stories and rendering logic imply the required shape:
+
+- `key: string`
+- `name: string`
+- `icon: string`
+
+Additional wallet fields may exist upstream, but those are the fields this package reads today.
+
+### Handle Objects
+
+The shared interface stack is:
+
+- `BasicAsset`
+  - `policyId`
+  - `hex`
+- `Asset`
+  - `name`
+  - optional `count`
+  - optional `utxo`
+  - optional `image`
+  - optional `src`
+  - optional `price`
+  - optional `cost`
+  - optional `validUntilDate`
+- `WalletHandle`
+  - `active`
+  - `default`
+  - optional `image`
+  - optional `imageUrl`
+
+In practice, selector components use only a subset of this information:
+
+- `name`
+- `image` or external `imageUrl`
+- `active` in the large selector
+
+But the broader shape matters because it shows maintainers the domain assumptions embedded in the package.
+
+## Build Pipeline
+
+The package compiles with `tsc` using:
+
+- `target: ESNext`
+- `module: ESNext`
+- `outDir: ./lib`
+- declaration output enabled
+- experimental decorators enabled
+- `ts-lit-plugin` strict mode
+
+Because `outDir` is `./lib`, the package’s distributable JavaScript and declaration files are generated there. The repo also carries compiled `lib` output in version control today, which affects how Storybook and publishing are configured.
+
+## Storybook Model
+
+The package’s Storybook setup is tied to compiled output rather than source files:
+
+- `.storybook/main.js` points to `../lib/src/stories/**/*.stories.{js,md,mdx}`
+
+At the same time, the compiled stories visible in the repo live under `lib/stories`, not `lib/src/stories`.
+
+That discrepancy is worth recording for maintainers because it means Storybook configuration should be re-verified whenever the local demo workflow is touched. Even if the development server still works through other local assumptions, the documented path mismatch is a real maintenance concern.
+
+## Release And Deployment Model
+
+The repo publishes through GitHub Actions via `.github/workflows/deploy.yml`.
+
+Important facts:
+
+- publish triggers on pushes to `master`
+- manual `workflow_dispatch` is also enabled
+- the workflow delegates publishing to a shared deployment script from `koralabs/adahandle-deployments`
+- the deployment type is `npm-publish`
+- the job uses `NODE_VERSION: 20`
+- `IS_PUBLIC: true` is set
+
+This indicates the package is intended to be distributed as a public npm package rather than deployed as a web app.
+
+## Branch Reality
+
+The execution context for this documentation task referenced `main`, but the repository and deploy workflow are currently aligned to `master`.
+
+Architecturally, that matters because:
+
+- any automation that assumes `main` will not match the repo’s actual publish trigger
+- maintainers need to know the branch contract before editing workflows or release instructions
+- documentation should reflect current reality, not a hypothetical future branch rename
+
+If the repo is later renamed to `main`, these docs should be updated together with the workflow.
+
+## Current Gaps And Technical Debt
+
+The documentation effort surfaced several implementation facts that future maintainers should treat as explicit debt rather than invisible behavior:
+
+- the package root export surface is incomplete relative to the available component set
+- callback properties and custom events are mixed without one uniform convention
+- some components are presentational only and rely entirely on host-driven state changes
+- `select-wallet` carries internal `selectedWallet` state that is not updated on click
+- Storybook configuration should be revalidated because the configured story path does not match the checked-in compiled layout
+- there are no automated tests defined in `package.json`
+
+These are not blockers for using the package, but they are important for planning future cleanup or API hardening.
+
+## Maintainer Guidance
+
+When extending this repo, preserve three constraints unless there is an intentional API change:
+
+- keep the components clearly separated from business logic and data fetching
+- document any new slot, callback, event, or root export as part of the public contract
+- treat `lib` output, Storybook behavior, and publish workflow as one connected packaging system rather than three independent concerns
+
+That mindset will help the repo evolve from a useful internal package into a cleaner, more predictable shared UI module.

--- a/docs/spec/build-release.md
+++ b/docs/spec/build-release.md
@@ -1,0 +1,246 @@
+# Build, Storybook, And Release
+
+## Overview
+
+This repo is published as an npm package, not deployed as a standalone application. That shapes the local workflow:
+
+- source code is authored in `src`
+- TypeScript compiles to `lib`
+- Storybook examples are part of the developer experience
+- GitHub Actions publishes the package
+
+For maintainers, the important point is that build output, checked-in artifacts, stories, and release automation are connected. If one part changes, the others need to be checked too.
+
+## Package Metadata
+
+Current `package.json` facts:
+
+- package name: `@koralabs/handles-shared-lit-components`
+- version: `0.3.12`
+- package type: `module`
+- homepage: `https://github.com/koralabs/handles-shared-lit-components`
+- repository URL points at the same GitHub repo
+
+Dependencies:
+
+- `lit`
+- `lit-html`
+
+Notable dev dependencies:
+
+- `typescript`
+- `ts-lit-plugin`
+- `@web/dev-server`
+- `@web/dev-server-storybook`
+- `@storybook/addon-essentials`
+- `concurrently`
+
+The dependency set is intentionally light and aligned with a small shared UI package rather than a full application framework.
+
+## Available Scripts
+
+### `npm run build`
+
+Runs:
+
+```bash
+tsc
+```
+
+This compiles `src` to `lib`, emits declaration files, and fails on TypeScript errors because `noEmitOnError` is enabled.
+
+Use it when:
+
+- validating any source change
+- preparing updated `lib` output
+- checking that Storybook stories still typecheck as part of the repo
+
+### `npm run build:local`
+
+Runs:
+
+```bash
+yarn build && cp package.json ./lib/package.json && cd lib && npm i --production
+```
+
+This script appears intended for local linking or testing of the compiled output as a package-shaped directory.
+
+Operational implications:
+
+- it assumes `yarn` is available even though the repo also carries `package-lock.json`
+- it copies `package.json` into `lib`
+- it installs production dependencies inside `lib`
+
+That makes it useful for package-consumption experiments, but it also reflects mixed package-manager assumptions that maintainers should keep in mind.
+
+### `npm run storybook`
+
+Runs:
+
+```bash
+tsc && concurrently -k -r "tsc --watch --preserveWatchOutput" "wds --watch -c .storybook/server.mjs --hmr"
+```
+
+This establishes an incremental development loop:
+
+- initial TypeScript build
+- background TypeScript watch
+- web dev server with Storybook integration
+
+Use it when:
+
+- iterating on component visuals
+- validating that a changed component still renders in example form
+- checking how slots, props, and callbacks behave in a browser context
+
+## TypeScript Configuration
+
+`tsconfig.json` encodes several important decisions:
+
+- modern `ESNext` target and module output
+- DOM library support
+- emitted declarations and declaration maps
+- experimental decorators enabled
+- `useDefineForClassFields: false`, which is common in Lit projects that rely on decorator semantics
+- `jsx: react-jsx`, which is relevant because the repo also contains a template helper with React-like prop naming even though the main component system is Lit
+- `ts-lit-plugin` in strict mode
+
+Maintainer takeaway:
+
+- changes to decorators, property definitions, or Lit templates should always be checked through `npm run build`
+- if new files are added, they should preserve the same decorator and module assumptions unless the whole package is being modernized deliberately
+
+## Storybook Notes
+
+The repo contains both stories and Storybook configuration, but the current setup should be understood carefully.
+
+Story sources:
+
+- live authoring files are in `src/stories`
+- compiled outputs are in `lib/stories`
+
+Configured story glob:
+
+- `.storybook/main.js` points to `../lib/src/stories/**/*.stories.{js,md,mdx}`
+
+That means maintainers should verify Storybook behavior whenever they touch the docs, demo setup, or output layout. The codebase currently documents a path that does not line up with the checked-in `lib/stories` structure.
+
+The safest workflow is:
+
+1. run `npm run build`
+2. inspect the compiled story output under `lib`
+3. run `npm run storybook`
+4. confirm the expected stories appear
+
+If story discovery is inconsistent, the first place to inspect is the `.storybook/main.js` path configuration.
+
+## Checked-In Build Output
+
+The `lib` folder is present in the repository. That means:
+
+- generated artifacts are part of the tracked tree
+- maintainers should expect source edits to produce corresponding compiled changes
+- Storybook and publish workflows may depend on the compiled layout being present and up to date
+
+This is different from repos that ignore build output entirely. Here, source and generated files are part of one operational unit.
+
+For documentation-only changes, `lib` should normally remain unchanged.
+
+## Publish Workflow
+
+The GitHub Actions workflow is `.github/workflows/deploy.yml`.
+
+Trigger conditions:
+
+- push to `master`
+- manual `workflow_dispatch`
+
+Job characteristics:
+
+- job name: `Deploying from ${{ github.ref_name }}`
+- environment: `mainnet`
+- runner: `ubuntu-latest`
+
+Publish mechanism:
+
+- checks out the repo
+- downloads the shared `main.sh` deployment script from `koralabs/adahandle-deployments`
+- runs it with environment variables indicating an npm publish
+
+Relevant environment variables in the workflow:
+
+- `DEPLOYMENT_TYPE: npm-publish`
+- `NODE_VERSION: 20`
+- `IS_PUBLIC: true`
+
+This tells maintainers three important things:
+
+- publishing behavior is standardized through the shared deployment repo rather than defined inline
+- branch correctness matters because the workflow listens to `master`
+- npm package publication is part of the expected repository lifecycle, not an afterthought
+
+## Branching Reality
+
+The repository currently publishes from `master`, and `origin/master` is the remote default branch. Any local or external process that assumes `main` is out of sync with the actual repo configuration.
+
+Why this matters:
+
+- release instructions must name the real publish branch
+- automation should not be updated casually without checking the workflow trigger
+- maintainers working across the Kora ecosystem should note this repo-specific exception if other repos have already standardized on `main`
+
+If the branch is renamed later, the workflow, package docs, and any downstream automation should be updated together.
+
+## Verification For Documentation-Only Work
+
+For documentation-only changes in this repo, a reasonable verification sequence is:
+
+```bash
+npm run build
+find docs -type f | sort
+python3 - <<'PY'
+from pathlib import Path
+import re
+total = 0
+for path in Path('docs').rglob('*.md'):
+    if path.parts[1] in {'product', 'spec'}:
+        total += len(re.findall(r\"\\b\\w+\\b\", path.read_text()))
+print(total)
+PY
+```
+
+Interpretation:
+
+- `npm run build` proves the source package still compiles
+- listing docs confirms the new documentation tree is present
+- the word-count check proves readiness content exists in both `docs/product` and `docs/spec`
+
+## Current Risks For Future Maintainers
+
+When changing the repo’s packaging or developer workflow, watch for these risks:
+
+- expanding the root export surface without documenting it can create accidental public API
+- changing Storybook paths without verifying compiled layout can silently break demos
+- changing branch names without updating publish workflow can stop releases
+- changing source files without rebuilding can leave `lib` stale relative to `src`
+- assuming all components are self-contained interactive controls can lead to incorrect host integration, because several controls are intentionally presentational
+
+## Recommended Maintenance Discipline
+
+For changes that affect runtime code:
+
+1. update the source in `src`
+2. run `npm run build`
+3. verify the affected story if one exists
+4. check whether `lib` changed as expected
+5. update docs when the public behavior or workflow changed
+
+For changes that affect packaging:
+
+1. inspect `package.json`
+2. inspect `tsconfig.json`
+3. inspect `.storybook`
+4. inspect `.github/workflows/deploy.yml`
+5. document the new contract in `docs/spec`
+
+That discipline is the simplest way to keep this package usable across the Handles ecosystem without letting its implicit conventions drift further out of sync with the code.

--- a/docs/spec/component-contracts.md
+++ b/docs/spec/component-contracts.md
@@ -1,0 +1,567 @@
+# Component Contracts
+
+This page records the practical contract of every component and helper in the repo. It is intentionally explicit because the package currently mixes side-effect imports, callback props, slots, and a narrow root export surface.
+
+## Conventions Used Here
+
+- “Properties” are reactive Lit properties or function props accepted by the element.
+- “Slots” are named insertion points exposed to consumers.
+- “Outputs” are callbacks invoked by the component or browser events dispatched from it.
+- “Controlled by parent” means the host application is expected to own the state transition and re-render the component accordingly.
+
+## Shared Button Family
+
+Source: `src/web-components/Button/index.ts`
+
+Registered tags:
+
+- `shared-button-small`
+- `shared-button-medium`
+- `shared-button-large`
+
+### Properties
+
+- `buttonColor?: string`
+- `textColor?: string`
+- `hoverColor?: string`
+
+### Slots
+
+- `shared-button`: the button label/content
+
+### Outputs
+
+- no custom callbacks
+- no custom events
+- native click can still be listened for on the host element
+
+### Render Behavior
+
+All three tags share the same base class and differ only in CSS sizing:
+
+- small: 12px font, `10px 16px` padding
+- medium: 14px font, `11px 20px` padding
+- large: 16px font, `12px 24px` padding
+
+The rendered `<button>` receives the background and text colors via inline style bindings.
+
+### Integration Notes
+
+- The component is a simple shell and does not expose disabled or loading semantics.
+- The label must be passed via slot content, usually wrapped in `<div slot="shared-button">...</div>` inside the custom element.
+
+## `select-wallet`
+
+Source: `src/web-components/SelectWallet/index.ts`
+
+Custom element tag: `select-wallet`
+
+### Properties
+
+- `slottedButtonsStyling: string = ''`
+- `onFirstUpdated: Function = () => {}`
+- `onScroll: Function = () => {}`
+- `onSelectWallet: Function = (wallet) => {}`
+- `wallets: any[] = []`
+
+Internal reactive state:
+
+- `selectedWallet: string = ''`
+
+### Slots
+
+- `slottedButtons`
+
+### Outputs
+
+- invokes `onFirstUpdated()` during `firstUpdated()`
+- invokes `onSelectWallet(wallet)` when the user clicks a wallet row
+- binds `onScroll` directly to the wallet list container’s `scroll` event
+
+### Data Shape Expected
+
+Each wallet row expects at least:
+
+- `wallet.key`
+- `wallet.name`
+- `wallet.icon`
+
+### Render Behavior
+
+- Displays a fixed “Choose your wallet” header
+- Shows a scrollable list if `wallets.length > 0`
+- Shows “No supported wallet extensions found.” if the list is empty
+- Renders a radio-style selected indicator through `renderSelectIcon`
+
+### Integration Notes
+
+- The internal `selectedWallet` state is not updated in the click handler. The current handler calls only `onSelectWallet(wallet)`. As a result, consumers should treat the built-in selected styling as incomplete until the component is updated or wrapped.
+- Because selection is callback-driven instead of event-driven, usage is simplest in Lit templates or other frameworks that can pass function properties cleanly.
+- Footer buttons are not provided by default; the host supplies them through the slot.
+
+## `handle-small-search`
+
+Source: `src/web-components/SmallHandleSearch/index.ts`
+
+Custom element tag: `handle-small-search`
+
+### Properties
+
+- `inputValue?: string`
+- `searching: boolean = false`
+
+### Slots
+
+- none
+
+### Outputs
+
+- dispatches `input-change` as a bubbling, composed `CustomEvent`
+- event detail shape: `{ inputValue: string }`
+
+### Methods With External Effect
+
+- `handleInput(event)` trims the input, sets local state, dispatches `input-change`, and requests an update
+- `clearSearch()` clears local state and requests an update
+
+### Render Behavior
+
+- Shows a search icon on the left
+- Uses `search for your handle` as the default placeholder
+- Changes the placeholder on focus to `Type $ for exact match`
+- Shows a clear icon region that becomes visible when `searching` is true
+
+### Integration Notes
+
+- The component is suitable as a child of `select-handle` or `large-handle-selector`, but it can also be used independently.
+- Clearing the search does not itself dispatch a new `input-change` event. If the host depends on an explicit “cleared” event, it must add that behavior around the component.
+
+## `dropdown-button`
+
+Source: `src/web-components/DropdownButton/index.ts`
+
+Custom element tag: `dropdown-button`
+
+### Properties
+
+- `dropdownHandle: string = ''`
+- `dropdownPositioning: string = ''`
+
+Internal reactive state:
+
+- `dropdownOpen: boolean = false`
+
+### Slots
+
+- `slottedDropdown`
+
+### Outputs
+
+- no callback props
+- no custom events
+- internal click handler toggles the dropdown open state
+
+### Render Behavior
+
+- Displays a Handles logo SVG
+- Displays `dropdownHandle` or the fallback text `Choose Handle`
+- Rotates the arrow icon when `dropdownOpen` is true
+- Applies `dropdownPositioning` as the inline style of the dropdown container while open
+- Hides the dropdown content entirely when closed with `display: none;`
+
+### Integration Notes
+
+- Since the component does not emit an “opened” or “closed” event, consumers who need side effects tied to open state must wrap or extend it.
+- The component imports `LitElement` from `lit-element` rather than `lit`, which is inconsistent with the rest of the repo but currently part of the implementation reality.
+
+## `select-handle`
+
+Source: `src/web-components/SelectHandle/index.ts`
+
+Custom element tag: `select-handle`
+
+### Properties
+
+- `handleData: any[] = []`
+- `loadingImg: boolean = false`
+- `slottedButtonsStyling: string = ''`
+- `slottedSearchStyling: string = ''`
+- `imageUrl: string = ''`
+- `activeHandle: any = {}`
+- `onFirstUpdated: Function = () => {}`
+- `onScroll: Function = () => {}`
+- `onSelectHandle: Function = (handle) => {}`
+
+### Slots
+
+- `slottedSearch`
+- `slottedButtons`
+- `slottedLoader`
+
+### Outputs
+
+- invokes `onFirstUpdated()` during `firstUpdated()`
+- invokes `onScroll` from the outer scroll container
+- invokes `onSelectHandle({ ...handle })` when the user clicks a handle row
+
+### Data Shape Expected
+
+The component reads:
+
+- `handle.name`
+
+The parent is also expected to pass:
+
+- `activeHandle.name`
+- `imageUrl` for the active handle image
+
+### Render Behavior
+
+- Renders the slotted search container at the top
+- Optionally renders a current-handle block when `activeHandle?.name` is truthy
+- Renders each list row with a `$` prefix
+- Highlights the row whose `handle.name` matches `activeHandle?.name`
+- Shows the loader slot instead of the active image when `loadingImg` is true
+- Also appends loader slot content after the list when `loadingImg` is true
+
+### Integration Notes
+
+- The component does not derive image URLs from the handle object; the current image path is supplied separately as `imageUrl`.
+- Because `onSelectHandle` receives a shallow copy of the clicked handle, host code can safely enrich or compare the returned object without mutating the array element directly.
+- Styling hooks for the search and button regions are raw string properties, not structured style APIs.
+
+## `large-handle-selector`
+
+Source: `src/web-components/LargeHandleSelector/index.ts`
+
+Custom element tag: `large-handle-selector`
+
+### Properties
+
+- `handleData: any[] = []`
+- `handleDataArray: any`
+- `dropdownOpen: boolean = false`
+- `isLoading: boolean = false`
+- `imageUrl: string = ''`
+- `imgWidth: string = ''`
+- `imgHeight: string = ''`
+- `slottedSearchStyling: string = ''`
+- `onFirstUpdated: Function = () => {}`
+- `onScroll: Function = () => {}`
+- `onSelectHandle: Function = (handle) => {}`
+
+### Slots
+
+- `slottedSearch`
+- `slottedLoader`
+
+### Outputs
+
+- invokes `onFirstUpdated()` during `firstUpdated()`
+- invokes `onScroll` on the inner scroll wrapper
+- invokes `onSelectHandle(handle)` when the user clicks a handle image card
+
+### Data Shape Expected
+
+The component is most aligned with the shared `WalletHandle` interface and reads:
+
+- `handle.active`
+- `handle.image`
+
+### Render Behavior
+
+- Displays a fixed “Choose your handle” title
+- Chooses image dimensions based on list size:
+  - one item: `19rem`
+  - two to ten items: `10rem`
+  - more than ten items: `5rem`
+- Renders loader slot content when a handle item lacks `image`
+- Applies an `active` class when `handle.active` is truthy
+- Wraps the scroll area with a gradient overlay
+
+### Integration Notes
+
+- `imageUrl` exists as a property but the current render path uses `handleData.image` for each tile rather than the `imageUrl` property.
+- The `handleDataArray`, `dropdownOpen`, and `isLoading` properties are currently not central to the rendered output and should not be treated as stable public API without intentional cleanup.
+
+## `disconnect-wallet-button`
+
+Source: `src/web-components/DisconnectWalletButton/index.ts`
+
+Custom element tag: `disconnect-wallet-button`
+
+### Properties
+
+- `walletIconUrl!: string`
+- `showHoverIcon: boolean = false`
+- `onClick: Function = () => {}`
+
+### Slots
+
+- none
+
+### Outputs
+
+- invokes `onClick()` when the wrapper is clicked
+
+### Render Behavior
+
+- Shows `walletIconUrl` if present, otherwise a generic wallet icon
+- On hover, swaps the wallet icon for a disconnect glyph
+- Displays tooltip text `Disconnect Wallet`
+
+### Integration Notes
+
+- This component is optimized for a compact visual affordance, not a verbose CTA.
+- The hover-driven affordance means parent apps should consider touch-device discoverability when placing it in mobile-heavy flows.
+
+## `confirm-popup`
+
+Source: `src/web-components/ConfirmPopup/index.ts`
+
+Custom element tag: `confirm-popup`
+
+### Properties
+
+- `open: boolean = false`
+- `message: string = ''`
+- `secondMessage: string = ''`
+- `confirmButtonLabel: string = ''`
+- `cancelButtonLabel: string = ''`
+- `onConfirm: (() => void) | null = null`
+- `onCancel: (() => void) | null = null`
+
+### Slots
+
+- none
+
+### Outputs
+
+- invokes `onConfirm()` if present, then closes itself
+- invokes `onCancel()` if present, then closes itself
+
+### Render Behavior
+
+- Applies `show` class to the modal root when `open` is true
+- Renders two `shared-button-small` buttons with fixed color treatments
+- Uses `message` and `secondMessage` as the dialog body copy
+
+### Integration Notes
+
+- The component mutates its own `open` state via `closePopup()`. If the host mirrors `open` externally, it should keep that state in sync.
+- No semantic close event is emitted. Consumers must infer closure from the callbacks they pass or by inspecting state.
+
+## `error-popup`
+
+Source: `src/web-components/ErrorPopup/index.ts`
+
+Custom element tag: `error-popup`
+
+### Properties
+
+- `open: boolean = true`
+- `message: string = ''`
+- `messageTitle: string = ''`
+- `countdown: number = 5`
+
+Internal fields:
+
+- `countdownInterval: number | null = null`
+- `maxCountdown: number = 5`
+- `isPaused: boolean = false`
+
+### Slots
+
+- `customError`
+
+### Outputs
+
+- dispatches `error-popup-closed` on `window` when `closePopup()` runs
+
+### Lifecycle Behavior
+
+- `connectedCallback()` attaches hover listeners
+- `disconnectedCallback()` removes hover listeners
+- `firstUpdated()` starts the countdown timer
+
+### Render Behavior
+
+- Renders a modal shell with alert icon, title, body, and close button
+- Shrinks the progress bar as `countdown` decreases
+- Pauses the countdown on mouse enter
+- Resumes on mouse leave
+- Resets countdown to `maxCountdown` when closed
+
+### Integration Notes
+
+- The public `countdown` property suggests configurability, but the internal timer logic resets from a fixed `maxCountdown` value of five seconds. Treat the five-second behavior as the current authoritative implementation.
+- Because the close event is dispatched on `window`, hosts should register listeners accordingly if they need closure notifications.
+
+## `custom-toggle`
+
+Source: `src/web-components/CustomToggle/index.ts`
+
+Custom element tag: `custom-toggle`
+
+### Properties
+
+- `isActive: boolean = false`
+- `smallToggle: boolean = false`
+
+### Slots
+
+- none
+
+### Outputs
+
+- no custom callbacks
+- no custom events
+
+### Render Behavior
+
+- Applies `toggled` and `small` classes based on the supplied boolean props
+- Renders a line and circle visual that represents the toggle position
+
+### Integration Notes
+
+- The component does not manage its own state transitions. A parent app should update `isActive` in response to user interaction if the control is meant to be interactive.
+
+## `custom-checkbox`
+
+Source: `src/web-components/CustomCheckBox/index.ts`
+
+Custom element tag: `custom-checkbox`
+
+### Properties
+
+- `checked: boolean = false`
+- `smallCheckbox: boolean = false`
+- `disabled: boolean = false`
+
+### Slots
+
+- none
+
+### Outputs
+
+- no custom callbacks
+- no custom events
+
+### Render Behavior
+
+- Applies `checked`, `small`, and `disabled` classes to the wrapper
+- Renders the checkmark SVG only when `checked` is true
+
+### Integration Notes
+
+- This component is display-only in its current form. If used as an interactive form control, the host should handle accessibility roles, keyboard behavior, and state updates.
+
+## `radio-button`
+
+Source: `src/web-components/RadioButton/index.ts`
+
+Custom element tag: `radio-button`
+
+### Properties
+
+- `isSelected: boolean = true`
+- `isSmall: boolean = true`
+
+### Slots
+
+- none
+
+### Outputs
+
+- none
+
+### Render Behavior
+
+- Renders nested selected or unselected divs
+- Applies a small variant class when `isSmall` is true
+
+### Integration Notes
+
+- This is a styling primitive rather than a complete radio input control.
+
+## `state-example`
+
+Source: `src/web-components/StateExample/index.ts`
+
+Custom element tag: `state-example`
+
+### Properties
+
+- `count: number = 0`
+- `title: string = ''`
+
+### Slots
+
+- default slot
+
+### Outputs
+
+- no custom callbacks
+- no custom events
+
+### Render Behavior
+
+- Renders a heading and a button that increments `count`
+- Uses `--my-counter-text-color` CSS custom property to color all text
+
+### Integration Notes
+
+- This is a demo component and should not be treated as a domain-specific production primitive.
+
+## Template Helpers In `src/components`
+
+These helpers are part of the repo contract even though they are not registered custom elements.
+
+### `Button`
+
+Source: `src/components/Button/index.ts`
+
+Properties via `ButtonProps`:
+
+- `primary?: boolean`
+- `backgroundColor?: string`
+- `size?: 'small' | 'medium' | 'large'`
+- `label: string`
+- `onClick?: () => void`
+
+Behavior:
+
+- returns a Lit template for a styled native button
+- computes a primary or secondary class
+- applies `backgroundColor` through `styleMap`
+
+Notes:
+
+- This helper is separate from the custom-element button family and resembles a Storybook-friendly template primitive.
+
+### `CustomLoader`
+
+Source: `src/components/CustomLoader/index.ts`
+
+Properties:
+
+- none
+
+Behavior:
+
+- returns a Lit template that renders a dual-SVG animated loader
+
+Notes:
+
+- Suitable for slotted loading surfaces or inline waiting states where a branded loader is desired.
+
+## Cross-Cutting Contract Guidance
+
+If you are integrating or extending this package, the safest assumptions are:
+
+- selector and dialog components prefer callback properties over emitted events
+- slotted composition is the main extension mechanism for larger shells
+- several controls are presentational only and depend on parent-managed state
+- the root package export is incomplete, so direct module imports may still be required
+
+Any future cleanup should document changes against this page explicitly, because the current contract is defined as much by implementation habit as by formal package API design.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     },
     "scripts": {
         "lint": "echo \"Error: no lint specified\"",
-        "test": "echo \"Error: no test specified\"",
+        "test": "npm run build && node --test tests/*.test.mjs",
+        "test:coverage": "npm run build && node --experimental-test-coverage --test tests/*.test.mjs",
         "build": "tsc",
         "build:local": "yarn build && cp package.json ./lib/package.json && cd lib && npm i --production",
         "storybook": "tsc && concurrently -k -r \"tsc --watch --preserveWatchOutput\" \"wds --watch -c .storybook/server.mjs --hmr\""

--- a/tests/components.test.mjs
+++ b/tests/components.test.mjs
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CustomLoader, StateExample } from '../lib/index.js';
+import {
+    SharedButtonLarge,
+    SharedButtonMedium,
+    SharedButtonSmall
+} from '../lib/web-components/Button/index.js';
+import { SelectHandle } from '../lib/web-components/SelectHandle/index.js';
+
+const valueText = (value) => String(value);
+
+const templateText = (template) => {
+    const strings = Array.from(template.strings ?? []);
+    const values = Array.from(template.values ?? []);
+    let text = strings[0] ?? '';
+
+    for (let index = 0; index < values.length; index++) {
+        const value = values[index];
+        if (Array.isArray(value)) {
+            text += value.map(templateText).join('');
+        } else if (value?.strings) {
+            text += templateText(value);
+        } else if (typeof value !== 'function') {
+            text += valueText(value);
+        }
+        text += strings[index + 1] ?? '';
+    }
+
+    return text;
+};
+
+test('StateExample renders title/count and increments from the click binding', () => {
+    const element = new StateExample();
+    element.title = 'Wallet state';
+    element.count = 4;
+
+    const rendered = element.render();
+    assert.equal(rendered.values[0], 'Wallet state');
+    assert.equal(rendered.values[2], 4);
+    assert.match(templateText(rendered), /The count is 34434:/);
+
+    rendered.values[1]();
+    assert.equal(element.count, 5);
+});
+
+test('StateExample exposes the documented custom element tag and default state', () => {
+    const element = customElements.get('state-example');
+
+    assert.equal(element, StateExample);
+    assert.equal(new element().count, 0);
+});
+
+test('SelectHandle renders the active handle, image URL, and active class', () => {
+    const element = new SelectHandle();
+    element.handleData = [
+        { name: 'ada', image: 'ipfs://ada' },
+        { name: 'kora', image: 'ipfs://kora' }
+    ];
+    element.activeHandle = { name: 'ada' };
+    element.imageUrl = 'https://example.test/ada.png';
+
+    const rendered = element.render();
+    const currentHandle = rendered.values[1];
+    const handleItems = rendered.values[3];
+
+    assert.match(templateText(currentHandle), /current-handle/);
+    assert.equal(currentHandle.values[0].values[0], 'https://example.test/ada.png');
+    assert.equal(currentHandle.values[1], 'ada');
+    assert.equal(handleItems.length, 2);
+    assert.equal(handleItems[0].values[1], 'active');
+    assert.equal(handleItems[0].values[3], 'ada');
+    assert.equal(handleItems[1].values[1], '');
+    assert.equal(handleItems[1].values[3], 'kora');
+});
+
+test('SelectHandle click binding calls onSelectHandle with a copied handle', () => {
+    const selected = [];
+    const sourceHandle = { name: 'kora', image: 'ipfs://kora' };
+    const element = new SelectHandle();
+    element.handleData = [sourceHandle];
+    element.onSelectHandle = (handle) => selected.push(handle);
+
+    const rendered = element.render();
+    const firstItem = rendered.values[3][0];
+    firstItem.values[0]();
+
+    assert.deepEqual(selected, [sourceHandle]);
+    assert.notEqual(selected[0], sourceHandle);
+});
+
+test('SelectHandle switches active handle imagery to loader slots while loading', () => {
+    const element = new SelectHandle();
+    element.handleData = [{ name: 'ada', image: 'ipfs://ada' }];
+    element.activeHandle = { name: 'ada' };
+    element.loadingImg = true;
+
+    const rendered = element.render();
+    const currentHandle = rendered.values[1];
+    const handleItems = rendered.values[3];
+
+    assert.match(templateText(currentHandle.values[0]), /slot name="slottedLoader"/);
+    assert.doesNotMatch(templateText(handleItems[0].values[2]), /handle-img/);
+    assert.match(templateText(rendered.values[4]), /slot name="slottedLoader"/);
+});
+
+test('SelectHandle calls lifecycle and scroll callbacks supplied by consumers', () => {
+    let firstUpdated = 0;
+    let scrollEvent;
+    const element = new SelectHandle();
+    element.onFirstUpdated = () => firstUpdated++;
+    element.onScroll = (event) => {
+        scrollEvent = event;
+    };
+
+    element.firstUpdated();
+    const rendered = element.render();
+    const event = { type: 'scroll' };
+    rendered.values[2](event);
+
+    assert.equal(firstUpdated, 1);
+    assert.equal(scrollEvent, event);
+});
+
+test('shared button variants render their custom elements and slotted button content', () => {
+    for (const [tagName, ButtonClass] of [
+        ['shared-button-small', SharedButtonSmall],
+        ['shared-button-medium', SharedButtonMedium],
+        ['shared-button-large', SharedButtonLarge]
+    ]) {
+        assert.equal(customElements.get(tagName), ButtonClass);
+        assert.match(templateText(ButtonClass.renderTag()), new RegExp(`<${tagName}></${tagName}>`));
+
+        const button = new ButtonClass();
+        button.buttonClass = 'primary';
+        button.buttonColor = '#0DDD60';
+        button.textColor = '#101828';
+
+        const rendered = button.render();
+        const text = templateText(rendered);
+        assert.match(text, /shared-button primary/);
+        assert.match(text, /background-color: #0DDD60/);
+        assert.match(text, /color:#101828/);
+        assert.match(text, /slot name="shared-button"/);
+    }
+});
+
+test('CustomLoader renders both animated SVG layers', () => {
+    const rendered = CustomLoader();
+    const text = templateText(rendered);
+
+    assert.match(text, /class="loader"/);
+    assert.match(text, /class="green-svg"/);
+    assert.match(text, /class="blue-svg"/);
+    assert.match(text, /rotate-forward/);
+    assert.match(text, /rotate-reverse/);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
                 "strict": true
             }
         ]
-    }
+    },
+    "exclude": ["lib", "web-dev-server.config.mjs"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
             }
         ]
     },
-    "exclude": ["lib", "web-dev-server.config.mjs"]
+    "exclude": ["lib", "web-dev-server.config.mjs", "tests"]
 }


### PR DESCRIPTION
Coverage rotation: discovered no first-party tests or coverage tooling, wired npm test and npm run test:coverage with Node built-in test coverage, and added focused Lit template/callback tests for StateExample, SelectHandle, shared button variants, and CustomLoader.

Lesson: coverage-rotation-local-tooling-first
Verify: npm test passed from repo root with 8 node:test tests. Diagnostic: npm run test:coverage passed with all files at 99.87% lines, 75.53% branches, and 92.31% functions.